### PR TITLE
TPC-H: update queries to use 2.10+ datetime support

### DIFF
--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -39,10 +39,6 @@ jobs:
         run: |
           sudo apt-get install -y patch ccache luarocks libmsgpuck-dev libluajit-5.1-dev
 
-      - name: Patch sources
-        run: |
-          cd $GITHUB_WORKSPACE/$TARANTOOL_SRC/
-          patch -p1 < ../patches/0001-*.patch
         # by some odd reason we can't use
         #   working-directory: $GITHUB_WORKSPACE/tarantool/build
         # syntax - directory is not yet existing before actions 

--- a/create_table.lua
+++ b/create_table.lua
@@ -21,11 +21,11 @@ local function show_usage()
     )
 end
 
-for opt, arg in getopt(arg, 'm:p:', nonoptions) do
+for opt, v in getopt(arg, 'm:p:', nonoptions) do
     if opt == 'm' then
-        mem_size = arg
+        mem_size = v
     elseif opt == 'p' then
-        port = arg
+        port = v
     elseif opt == '?' then
         show_usage()
         os.exit(1)
@@ -126,7 +126,7 @@ CREATE TABLE ORDERS (
   O_CUSTKEY       INTEGER NOT NULL,
   O_ORDERSTATUS   TEXT NOT NULL,
   O_TOTALPRICE    DOUBLE NOT NULL,
-  O_ORDERDATE     STRING NOT NULL,
+  O_ORDERDATE     DATETIME NOT NULL,
   O_ORDERPRIORITY TEXT NOT NULL,
   O_CLERK         TEXT NOT NULL,
   O_SHIPPRIORITY  INTEGER NOT NULL,
@@ -147,9 +147,9 @@ CREATE TABLE LINEITEM (
   L_TAX           DOUBLE NOT NULL,
   L_RETURNFLAG    TEXT NOT NULL,
   L_LINESTATUS    TEXT NOT NULL,
-  L_SHIPDATE      STRING NOT NULL,
-  L_COMMITDATE    STRING NOT NULL,
-  L_RECEIPTDATE   STRING NOT NULL,
+  L_SHIPDATE      DATETIME NOT NULL,
+  L_COMMITDATE    DATETIME NOT NULL,
+  L_RECEIPTDATE   DATETIME NOT NULL,
   L_SHIPINSTRUCT  TEXT NOT NULL,
   L_SHIPMODE      TEXT NOT NULL,
   L_COMMENT       TEXT NOT NULL,
@@ -178,9 +178,14 @@ for _, tblname in ipairs(tables) do
           local cvt = tonumber(s)
           if cvt ~= nil then
             -- hack to retain doubleness for normalized numbers, e.g. 901.00
-            if string.match(s, '-?%d+%.%d+$') then
+            if s:match('-?%d+%.%d+$') then
               cvt = ffi.cast('double', cvt)
             end
+          -- hack to intercept datetime-like literals and convert to
+          -- proper cdata type
+          elseif s:match('%d%d%d%d%-%d%d%-%d%d') then
+            local datetime = require 'datetime'
+            cvt = datetime.parse(s)
           else
             cvt = s
           end

--- a/execute_query.lua
+++ b/execute_query.lua
@@ -207,19 +207,19 @@ local function show_usage()
     )
 end
 
-for opt, arg in getopt(arg, 'e:q:n:p:m:yvV', nonoptions) do
+for opt, v in getopt(arg, 'e:q:n:p:m:yvV', nonoptions) do
     if opt == 'q' then
-        queryN = arg
+        queryN = v
      -- explain is kinda dryrun, but with query plain displayed
     elseif opt == 'e' then
         explain = true
-        queryN = arg
+        queryN = v
     elseif opt == 'n' then
-        repeatN = arg
+        repeatN = v
     elseif opt == 'p' then
-        portN = arg
+        portN = v
     elseif opt == 'm' then
-        mem_size = arg
+        mem_size = v
     elseif opt == 'y' then
         dryrun = true
     elseif opt == 'v' then

--- a/queries/1.sql
+++ b/queries/1.sql
@@ -15,7 +15,7 @@ select
 from
 	lineitem
 where
-	l_shipdate <= date('1998-12-01', '-71 days')
+	l_shipdate <= cast('1998-12-01' as datetime) - cast({'day': 71} as interval)
 group by
 	l_returnflag,
 	l_linestatus

--- a/queries/10.sql
+++ b/queries/10.sql
@@ -18,8 +18,8 @@ from
 where
 	c_custkey = o_custkey
 	and l_orderkey = o_orderkey
-	and o_orderdate >= date('1994-01-01')
-	and o_orderdate < date('1994-01-01', '+ 3 months')
+	and o_orderdate >= cast('1994-01-01' as datetime)
+	and o_orderdate < cast('1994-01-01' as datetime) + cast({'month': 3} as interval)
 	and l_returnflag = 'R'
 	and c_nationkey = n_nationkey
 group by

--- a/queries/12.sql
+++ b/queries/12.sql
@@ -23,8 +23,8 @@ where
 	and l_shipmode in ('FOB', 'SHIP')
 	and l_commitdate < l_receiptdate
 	and l_shipdate < l_commitdate
-	and l_receiptdate >= date('1994-01-01')
-	and l_receiptdate < date('1994-01-01', '+ 1 year')
+	and l_receiptdate >= cast('1994-01-01' as datetime)
+	and l_receiptdate < cast('1994-01-01' as datetime) + cast({'year': 1} as interval)
 group by
 	l_shipmode
 order by

--- a/queries/14.sql
+++ b/queries/14.sql
@@ -2,15 +2,15 @@
 
 
 select
-	100.00 * sum(case
+	100.00 * sum(cast(case
 		when p_type like 'PROMO%'
 			then l_extendedprice * (1 - l_discount)
 		else 0
-	end) / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
+	end as number)) / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
 from
 	lineitem,
 	part
 where
 	l_partkey = p_partkey
-	and l_shipdate >= date('1994-03-01')
-	and l_shipdate < date('1994-03-01', '+1 month');
+	and l_shipdate >= cast('1994-03-01' as datetime)
+	and l_shipdate < cast('1994-03-01' as datetime) + cast({'month': 1} as interval);

--- a/queries/15.sql
+++ b/queries/15.sql
@@ -7,8 +7,8 @@ create view revenue0 (supplier_no, total_revenue) as
 	from
 		lineitem
 	where
-		l_shipdate >= date('1993-01-01')
-		and l_shipdate < date('1993-01-01', '+ 3 month')
+		l_shipdate >= cast('1993-01-01' as datetime)
+		and l_shipdate < cast('1993-01-01' as datetime) + cast({'month': 3} as interval)
 	group by
 		l_suppkey;
 

--- a/queries/18.sql
+++ b/queries/18.sql
@@ -31,6 +31,6 @@ group by
 	o_orderdate,
 	o_totalprice
 order by
-	o_totalprice,
+	o_totalprice desc,
 	o_orderdate
 limit 100;

--- a/queries/2.sql
+++ b/queries/2.sql
@@ -40,7 +40,7 @@ where
 			and r_name = 'MIDDLE EAST'
 	)
 order by
-	s_acctbal,
+	s_acctbal desc,
 	n_name,
 	s_name,
 	p_partkey

--- a/queries/20.sql
+++ b/queries/20.sql
@@ -30,8 +30,8 @@ where
 				where
 					l_partkey = ps_partkey
 					and l_suppkey = ps_suppkey
-					and l_shipdate >= date('1994-01-01')
-					and l_shipdate < date('1994-01-01', '+ 1 year')
+					and l_shipdate >= cast('1994-01-01' as datetime)
+					and l_shipdate < cast('1994-01-01' as datetime) + cast({'year': 1} as interval)
 			)
 	)
 	and s_nationkey = n_nationkey

--- a/queries/21.sql
+++ b/queries/21.sql
@@ -38,6 +38,6 @@ where
 group by
 	s_name
 order by
-	numwait,
+	numwait desc,
 	s_name
 limit 100;

--- a/queries/3.sql
+++ b/queries/3.sql
@@ -14,13 +14,13 @@ where
 	c_mktsegment = 'FURNITURE'
 	and c_custkey = o_custkey
 	and l_orderkey = o_orderkey
-	and o_orderdate < date('1995-03-29')
-	and l_shipdate > date('1995-03-29')
+	and o_orderdate < cast('1995-03-29' as datetime)
+	and l_shipdate > cast('1995-03-29' as datetime)
 group by
 	l_orderkey,
 	o_orderdate,
 	o_shippriority
 order by
-	revenue,
+	revenue desc,
 	o_orderdate
 limit 10;

--- a/queries/4.sql
+++ b/queries/4.sql
@@ -7,8 +7,8 @@ select
 from
 	orders
 where
-	o_orderdate >= date('1997-06-01')
-	and o_orderdate < date('1997-06-01','+ 3 months')
+	o_orderdate >= cast('1997-06-01' as datetime)
+	and o_orderdate < cast('1997-06-01' as datetime) + cast({'month': 3} as interval)
 	and exists (
 		select
 			*

--- a/queries/5.sql
+++ b/queries/5.sql
@@ -19,8 +19,8 @@ where
 	and s_nationkey = n_nationkey
 	and n_regionkey = r_regionkey
 	and r_name = 'MIDDLE EAST'
-	and o_orderdate >= date('1994-01-01')
-	and o_orderdate < date('1994-01-01',  '+ 1 year')
+	and o_orderdate >= cast('1994-01-01' as datetime)
+	and o_orderdate < cast('1994-01-01' as datetime) + cast({'year': 1} as interval)
 group by
 	n_name
 order by

--- a/queries/6.sql
+++ b/queries/6.sql
@@ -6,7 +6,7 @@ select
 from
 	lineitem
 where
-	l_shipdate >= date('1994-01-01')
-	and l_shipdate < date('1994-01-01', '+ 1 year')
+	l_shipdate >= cast('1994-01-01' as datetime)
+	and l_shipdate < cast('1994-01-01' as datetime) + cast({'year': 1} as interval)
 	and l_discount between 0.08 - 0.01 and 0.08 + 0.01
 	and l_quantity < 24;

--- a/queries/7.sql
+++ b/queries/7.sql
@@ -11,7 +11,7 @@ from
 		select
 			n1.n_name as supp_nation,
 			n2.n_name as cust_nation,
-			strftime('%Y', l_shipdate) as l_year,
+			date_part('year', l_shipdate) as l_year,
 			l_extendedprice * (1 - l_discount) as volume
 		from
 			supplier,
@@ -30,7 +30,8 @@ from
 				(n1.n_name = 'ROMANIA' and n2.n_name = 'INDIA')
 				or (n1.n_name = 'INDIA' and n2.n_name = 'ROMANIA')
 			)
-			and l_shipdate between date('1995-01-01') and date('1996-12-31')
+			and l_shipdate between 
+			cast('1995-01-01' as datetime) and cast('1996-12-31' as datetime)
 	) as shipping
 group by
 	supp_nation,

--- a/queries/8.sql
+++ b/queries/8.sql
@@ -3,14 +3,14 @@
 
 select
 	o_year,
-	sum(case
+	sum(cast(case
 		when nation = 'INDIA' then volume
 		else 0
-	end) / sum(volume) as mkt_share
+	end as number)) / sum(volume) as mkt_share
 from
 	(
 		select
-			strftime('%Y', o_orderdate) as o_year,
+			date_part('year', o_orderdate) as o_year,
 			l_extendedprice * (1 - l_discount) as volume,
 			n2.n_name as nation
 		from
@@ -31,7 +31,8 @@ from
 			and n1.n_regionkey = r_regionkey
 			and r_name = 'ASIA'
 			and s_nationkey = n2.n_nationkey
-			and o_orderdate between date('1995-01-01') and date('1996-12-31')
+			and o_orderdate between
+				cast('1995-01-01' as datetime) and cast('1996-12-31' as datetime)
 			and p_type = 'PROMO BRUSHED COPPER'
 	) as all_nations
 group by

--- a/queries/9.sql
+++ b/queries/9.sql
@@ -9,7 +9,7 @@ from
 	(
 		select
 			n_name as nation,
-			strftime('%Y', o_orderdate) as o_year,
+			date_part('year', o_orderdate) as o_year,
 			l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
 		from
 			part,


### PR DESCRIPTION
Massively update TPC-H queries to use datetime support available from 2.10+

1. Use DATETIME datet type for corresponding columns;
2. use `cast('2010-01-01' as datetime)` wherever standard TPC-H query insert simple literal `'2010-01-01'`to datetime column (as we do not handle implicit cast from string to datetime);
3. use `+ cast({'year': 1} as interval)` wherever we proceed interval arithmetic for standard expression of a kind ` - interval '1' year`, as we do not handle at the moment neither typed interval literals, nor implicit casts from strings in numeric context.
4. returned `desc` modifier in `group by` as we claimingly support them under `limit`.