### PR TITLE
tpch: extra careful loading of dbgen data

### DIFF
--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -1,7 +1,7 @@
 name: quick_check
 
 on:
-  push:
+  pull_request:
   repository_dispatch:
   workflow_dispatch:
 
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install tarantool build prerequisites
         run: |
-          sudo apt-get install -y patch ccache luarocks libmsgpuck-dev libluajit-5.1-dev
+          sudo apt-get install -y patch ccache luarocks libmsgpuck-dev libluajit-5.1-dev libunwind-dev
 
         # by some odd reason we can't use
         #   working-directory: $GITHUB_WORKSPACE/tarantool/build

--- a/create_table.lua
+++ b/create_table.lua
@@ -7,6 +7,8 @@ local mem_size = 10 * 1024^3
 
 local function config(portN, memSz)
     box.cfg{ listen = tonumber(portN), memtx_memory = tonumber(memSz) }
+    local fiber = require('fiber')
+    fiber.set_max_slice(60 * 60) -- "1 hour should be enough for everybody"
 end
 
 local function show_usage()

--- a/execute_query.lua
+++ b/execute_query.lua
@@ -20,6 +20,8 @@ io.stdout:setvbuf 'no'
 local function config(portN, memSz)
     if not dryrun then
         box.cfg{ listen = tonumber(portN), memtx_memory = tonumber(memSz) }
+        local fiber = require('fiber')
+        fiber.set_max_slice(60 * 60) -- "1 hour should be enough for everybody"
     end
 end
 


### PR DESCRIPTION
* Check expected results of loading of `dbgen` data, fail whole procedure if we have missed some rows;
* Extend fiber slice time as `require 'fiber'.set_max_slice(60 * 60)` to not abort data population procedure;

P.S.
* Discovered that there was no active CI connected with PR to this repository - so added the simple patch
  to run GH action on pull_request instead of push event.